### PR TITLE
Add unittests for API endpoint

### DIFF
--- a/TARS/tests/surfaces/API/api_test.py
+++ b/TARS/tests/surfaces/API/api_test.py
@@ -1,0 +1,24 @@
+import unittest
+from fastapi.testclient import TestClient
+from TARS.surfaces.API.api import app
+from TARS.graphs.agent import AgentManager
+
+class TestAPI(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_chat_endpoint_success(self):
+        response = self.client.post("/chat", json={"message": "Hello", "user_name": "TestUser"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("response", response.json())
+        self.assertIsInstance(response.json()["response"], str)
+
+    def test_chat_endpoint_invalid_input(self):
+        response = self.client.post("/chat", json={})
+        self.assertEqual(response.status_code, 422)
+
+    def test_chat_endpoint_error_handling(self):
+        with unittest.mock.patch.object(AgentManager, 'process_user_task', side_effect=Exception("Test Error")):
+            response = self.client.post("/chat", json={"message": "Hello", "user_name": "TestUser"})
+            self.assertEqual(response.status_code, 500)
+            self.assertEqual(response.json(), {"detail": "Internal Server Error"})


### PR DESCRIPTION
Adds unit tests for the API endpoints in `api_test.py` to ensure correctness and reliability of the API in various scenarios.

- **Setup and Dependencies**: Initializes `TestClient` with the FastAPI app and imports necessary modules including `unittest`, `fastapi.testclient`, and `AgentManager`.
- **Successful API Call Test**: Implements `test_chat_endpoint_success` to verify that the API returns a 200 status code and a string response when provided with valid input.
- **Invalid Input Test**: Adds `test_chat_endpoint_invalid_input` to check the API's response to missing input, expecting a 422 status code.
- **Error Handling Test**: Creates `test_chat_endpoint_error_handling` to simulate an internal server error using a mock object, verifying that the API correctly returns a 500 status code and an appropriate error message.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gpsandhu23/TARS?shareId=0d7e17ab-57e0-4a72-801e-951e6b540067).