### PR TITLE
Add missing unit tests for evaluators and LLM models

### DIFF
--- a/TARS/tests/evals/test_CI_evaluator.py
+++ b/TARS/tests/evals/test_CI_evaluator.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from evals.CI_evaluator import evaluate_single_prediction, process_evaluations
+
+class TestCIEvaluator(unittest.TestCase):
+
+    @patch('evals.CI_evaluator.process_user_task')
+    @patch('evals.CI_evaluator.load_evaluator')
+    def test_evaluate_single_prediction_success(self, mock_load_evaluator, mock_process_user_task):
+        # Setup mock response
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_strings.return_value = {"score": 0.8}
+        mock_load_evaluator.return_value = mock_evaluator
+        mock_process_user_task.return_value = "Test prediction"
+
+        # Test evaluate_single_prediction
+        input_text = "Test input"
+        reference = "Test reference"
+        result = evaluate_single_prediction(input_text, reference)
+        self.assertEqual(result, {"score": 0.8})
+
+    @patch('evals.CI_evaluator.process_user_task')
+    @patch('evals.CI_evaluator.load_evaluator')
+    def test_evaluate_single_prediction_error_handling(self, mock_load_evaluator, mock_process_user_task):
+        # Setup mock response to simulate an error
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_strings.side_effect = Exception("Evaluation error")
+        mock_load_evaluator.return_value = mock_evaluator
+        mock_process_user_task.return_value = "Test prediction"
+
+        # Test evaluate_single_prediction with error handling
+        input_text = "Test input"
+        reference = "Test reference"
+        with self.assertRaises(Exception):
+            evaluate_single_prediction(input_text, reference)
+
+    @patch('evals.CI_evaluator.evaluate_single_prediction')
+    def test_process_evaluations(self, mock_evaluate_single_prediction):
+        # Setup mock response
+        mock_evaluate_single_prediction.return_value = {"score": 0.8}
+
+        # Test process_evaluations with a mock file path
+        file_path = "mock_file_path.jsonl"
+        with patch('builtins.open', unittest.mock.mock_open(read_data='{"input": "Test input", "ideal": "Test ideal"}\n')) as mock_file:
+            process_evaluations(file_path)
+            mock_file.assert_called_with(file_path, 'r')
+            mock_evaluate_single_prediction.assert_called_with("Test input", "Test ideal")

--- a/TARS/tests/evals/test_agent_evaluator.py
+++ b/TARS/tests/evals/test_agent_evaluator.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from evals.agent_evaluator import evaluate_prediction
+
+class TestAgentEvaluator(unittest.TestCase):
+
+    @patch('evals.agent_evaluator.load_evaluator')
+    def test_evaluate_prediction_success(self, mock_load_evaluator):
+        # Setup mock response
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_strings.return_value = {"score": 0.9}
+        mock_load_evaluator.return_value = mock_evaluator
+
+        # Test evaluate_prediction
+        prediction = "This is a test prediction"
+        input_question = "What is a test prediction?"
+        result = evaluate_prediction(prediction, input_question)
+        self.assertEqual(result, {"score": 0.9})
+
+    @patch('evals.agent_evaluator.load_evaluator')
+    def test_evaluate_prediction_invalid_input(self, mock_load_evaluator):
+        # Setup mock response
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_strings.side_effect = ValueError("Invalid input")
+        mock_load_evaluator.return_value = mock_evaluator
+
+        # Test evaluate_prediction with invalid input
+        prediction = ""
+        input_question = ""
+        with self.assertRaises(ValueError):
+            evaluate_prediction(prediction, input_question)
+
+    @patch('evals.agent_evaluator.load_evaluator')
+    def test_evaluate_prediction_edge_case(self, mock_load_evaluator):
+        # Setup mock response for an edge case
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_strings.return_value = {"score": 0.0}  # Edge case: lowest possible score
+        mock_load_evaluator.return_value = mock_evaluator
+
+        # Test evaluate_prediction with edge case input
+        prediction = "Irrelevant prediction"
+        input_question = "What is the meaning of life?"
+        result = evaluate_prediction(prediction, input_question)
+        self.assertEqual(result, {"score": 0.0})

--- a/TARS/tests/models/generic_llms/test_anthropic.py
+++ b/TARS/tests/models/generic_llms/test_anthropic.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from TARS.models.generic_llms.anthropic import anthropic_llm
+
+class TestAnthropicLLM(unittest.TestCase):
+
+    @patch('TARS.models.generic_llms.anthropic.ChatAnthropic')
+    def test_initialization(self, mock_chat_anthropic):
+        # Test initialization with correct settings
+        mock_chat_anthropic.assert_called_with(model=anthropic_llm.model, temperature=anthropic_llm.temperature, api_key=anthropic_llm.api_key)
+
+    @patch('TARS.models.generic_llms.anthropic.ChatAnthropic')
+    def test_response_handling(self, mock_chat_anthropic):
+        # Mock API call to simulate different responses
+        mock_chat_anthropic_instance = MagicMock()
+        mock_chat_anthropic.return_value = mock_chat_anthropic_instance
+        mock_chat_anthropic_instance.invoke.return_value = "Test response"
+        
+        response = anthropic_llm.invoke("Test input")
+        self.assertEqual(response, "Test response")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/TARS/tests/models/generic_llms/test_google_ai.py
+++ b/TARS/tests/models/generic_llms/test_google_ai.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from TARS.models.generic_llms.google_ai import google_llm
+
+class TestGoogleLLM(unittest.TestCase):
+
+    @patch('TARS.models.generic_llms.google_ai.ChatGoogleGenerativeAI')
+    def test_initialization(self, mock_chat_google):
+        # Test initialization with correct settings
+        mock_chat_google.assert_called_with(model=google_llm.model, temperature=google_llm.temperature, api_key=google_llm.api_key)
+
+    @patch('TARS.models.generic_llms.google_ai.ChatGoogleGenerativeAI')
+    def test_response_handling(self, mock_chat_google):
+        # Mock API call to simulate different responses
+        mock_chat_google_instance = MagicMock()
+        mock_chat_google.return_value = mock_chat_google_instance
+        mock_chat_google_instance.invoke.return_value = "Test response"
+        
+        response = google_llm.invoke("Test input")
+        self.assertEqual(response, "Test response")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/TARS/tests/models/generic_llms/test_openai.py
+++ b/TARS/tests/models/generic_llms/test_openai.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from TARS.models.generic_llms.openai import openai_llm
+
+class TestOpenAILLM(unittest.TestCase):
+
+    @patch('TARS.models.generic_llms.openai.ChatOpenAI')
+    def test_initialization(self, mock_chat_openai):
+        # Test initialization with correct settings
+        mock_chat_openai.assert_called_with(model=openai_llm.model, temperature=openai_llm.temperature, api_key=openai_llm.api_key)
+
+    @patch('TARS.models.generic_llms.openai.ChatOpenAI')
+    def test_response_handling(self, mock_chat_openai):
+        # Mock API call to simulate different responses
+        mock_chat_openai_instance = MagicMock()
+        mock_chat_openai.return_value = mock_chat_openai_instance
+        mock_chat_openai_instance.invoke.return_value = "Test response"
+        
+        response = openai_llm.invoke("Test input")
+        self.assertEqual(response, "Test response")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related to #92

This pull request introduces comprehensive unit tests for previously untested modules, enhancing the test coverage of the TARS project.

- **Adds unit tests for evaluators**: Implements tests for `evals/agent_evaluator.py` and `evals/CI_evaluator.py`, covering successful evaluations, error handling, and edge cases. This ensures the reliability of the evaluation mechanisms for predictions and CI processes.
- **Introduces tests for LLM integrations**: New tests for `TARS/models/generic_llms/` directory, specifically for `anthropic.py`, `google_ai.py`, and `openai.py` modules. These tests verify the initialization and response handling of the LLM services, simulating different API responses to ensure robust integration.
- **Utilizes mocking extensively**: Throughout the added tests, external calls and dependencies are mocked to isolate the functionality being tested. This approach allows for precise control over the inputs and expected outputs, ensuring the tests are both reliable and repeatable.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gpsandhu23/TARS/issues/92?shareId=8a0cddfc-5583-4cfe-829a-9e167daa514b).